### PR TITLE
Fix cover features for Home Assistant 2022.04

### DIFF
--- a/custom_components/duofern/cover.py
+++ b/custom_components/duofern/cover.py
@@ -4,7 +4,14 @@ import logging
 # found advice in the homeassistant creating components manual
 # https://home-assistant.io/developers/creating_components/
 # Import the device class from the component that you want to support
-from homeassistant.components.cover import ATTR_POSITION, CoverEntity
+from homeassistant.components.cover import (
+    ATTR_POSITION,
+    CoverEntity,
+    SUPPORT_OPEN,
+    SUPPORT_CLOSE,
+    SUPPORT_SET_POSITION,
+    SUPPORT_STOP
+)
 
 from .const import DOMAIN
 
@@ -61,6 +68,10 @@ class DuofernShutter(CoverEntity):
     @property
     def unique_id(self):
         return self._id
+    
+    @property
+    def supported_features(self):
+        return SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_SET_POSITION | SUPPORT_STOP
 
     def open_cover(self):
         """roll up cover"""


### PR DESCRIPTION
After upgrading my Home Assistant Install to `2022.04.6`, I've been faced with some `cover.` entities refusing to be set to a specified position, because HA claimed that they wouldn't support that feature.
Indeed they were listed with `supported_features: 11` in the devtools.

Strangely, that only affected some of my covers, however I didn't bother further investigating the issue.

With this PR, all covers now report `supported_features: 15`.