### PR TITLE
Allow selecting /dev/duofernstick in config flow

### DIFF
--- a/custom_components/duofern/config_flow.py
+++ b/custom_components/duofern/config_flow.py
@@ -37,9 +37,10 @@ class DomainConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if os.path.isdir("/dev/"):
             serialdevs.update(set(glob.glob("/dev/ttyU*")))
             serialdevs.update(set(glob.glob("/dev/ttyA*")))
+            serialdevs.update(set(glob.glob("/dev/duofernstick")))
 
         if len(serialdevs) == 0:
-            serialdevs = set(["could not find /dev/serial/by-id/ or /dev/tty{U,A}*, did you plug in your duofern stick correctly?"])
+            serialdevs = set(["could not find /dev/serial/by-id/, /dev/tty{U,A}* or /dev/duofernstick. Did you plug in your duofern stick correctly?"])
 
         return self.async_show_form(
             step_id='user',


### PR DESCRIPTION
The readme in the pyduofern library repo suggests to create a udev rule that maps the duofern stick to `/dev/duofernstick`.
https://github.com/gluap/pyduofern#udev-configuration

I've been using the `custom_component` like that since the beginning but was left with no way of continuing to use it like that when upgrading to `0.5.7`. This change allows usage of that legacy(?) location without having to manually edit stuff in the home assistant `.storage` folder