### PR TITLE
Fix cover device metadata for HA 2023.8.3 and up

### DIFF
--- a/custom_components/duofern/cover.py
+++ b/custom_components/duofern/cover.py
@@ -94,8 +94,6 @@ class DuofernShutter(CoverEntity):
             },
             "manufacturer": "Rademacher",
             "name": self.name,
-            "default_manufacturer": "Rademacher",
-            "default_name": "Unkown Duofern Device",
         }  # type: ignore #(We only care about a subset and DeviceInfo doesn't mark the rest as optional)
 
     @property


### PR DESCRIPTION
After upgrading to `0.5.7` from `0.4.x` on my Home Assistant 2023.8.3 install, I did not see the cover entities show up in the device section.

Instead, I got log entries that looked like this:

```
2023-08-21 18:44:09.548 ERROR (MainThread) [homeassistant.components.cover] Ignoring invalid device info: Invalid device info {'default_manufacturer': 'Rademacher', 'default_name': 'Unkown Duofern Device', 'identifiers': {('duofern', '405725')}, 'manufacturer': 'Rademacher', 'name': '405725'} for 'duofern' config entry: device info needs to either describe a device, link to existing device or provide extra information.
```

That seems to be caused by these changes to Home Assistant that are 2 weeks old at the time of writing (check blame):
https://github.com/home-assistant/core/blob/4518dad83b47d63b76912c444ab4be159bc6af18/homeassistant/helpers/device_registry.py#L183-L193

To be completely honest, I do not really understand what exactly the issue is but I did find this PR that solves the same issue in a different component and doing the same as it does did also fix it for the duofern component so there's that.
https://github.com/home-assistant/core/pull/97843