### PR TITLE
Expose switch for sun automatic in rollotrons

### DIFF
--- a/custom_components/duofern/switch.py
+++ b/custom_components/duofern/switch.py
@@ -30,20 +30,25 @@ async def async_setup_entry(
     _LOGGER.info("switch: already added: " + str(stick.config['devices']))
 
     to_add: List[SwitchEntity] = []
-    for duofernDevice in stick.config['devices']:
-        duofernId: str = duofernDevice['id']
-        subId = "manualMode"
-        if not is_shutter(duofernId):
-            _LOGGER.info("switch: skipping: " + str(duofernId) + " because it is not a shutter")
-            continue
-        
-        if isDeviceSetUp(hass, duofernId, subId):
-            _LOGGER.info("switch: skipping: " + str(duofernId) + " because it is is already set up")
-            continue
 
-        switch = DuofernShutterConfigurableSwitch(duofernId, stick, "manualMode", "Manual Mode", "manual_mode")
-        to_add.append(switch)
-        saveDeviceAsSetUp(hass, switch, duofernId, subId)
+    shutterSwitches = {
+        "manualMode": ["manualMode", "Manual Mode", "manual_mode"],
+        "sunAutomatic": ["sunAutomatic", "Sun Automatic", "sun_automatic"]
+    }
+    for subId, [command, nameSuffix, idSuffix] in shutterSwitches.entries():
+        for duofernDevice in stick.config['devices']:
+            duofernId: str = duofernDevice['id']
+            if not is_shutter(duofernId):
+                _LOGGER.info("switch: skipping: " + str(duofernId) + " because it is not a shutter")
+                continue
+            
+            if isDeviceSetUp(hass, duofernId, subId):
+                _LOGGER.info("switch: skipping: " + str(duofernId) + " because it is is already set up")
+                continue
+
+            switch = DuofernShutterConfigurableSwitch(duofernId, stick, command, nameSuffix, idSuffix)
+            to_add.append(switch)
+            saveDeviceAsSetUp(hass, switch, duofernId, subId)
 
     async_add_entities(to_add)
 


### PR DESCRIPTION
The sun automatic can close a cover based on light exposure on a sensor that's stuck to the window. This can prevent overheating of a room. However, in spring and fall (or generally when it's not too hot outside) that actually might be desired. By exposing the switch that toggles this behaviour (de-)activating it can be automated in home assistant, e.g. by weather forecast.

I also tried exposing the other [switches from pyduofern](https://github.com/gluap/pyduofern/blob/master/pyduofern/duofern.py) while I was at it, but I didn't seem to fully understand them. Toggling the dusk and dawn automatic, for example, switches time, dusk and dawn automatic.